### PR TITLE
Too many arguments for HTML elements causes them to get dropped silently

### DIFF
--- a/src/joy/html.janet
+++ b/src/joy/html.janet
@@ -81,12 +81,19 @@
     [acc child]
     (string acc (create child)))
 
+  (defn safely [children]
+    (if (< 1 (length children))
+      (do
+        (print "Warning - too many children for element:")
+        (pp children)))
+    (first-child children))
+
   (let [child (first-child children)]
     (cond
       (indexed? child) (reduce child-reducer "" children)
       (keyword? child) (create children)
-      (string? child) (escape child)
-      (number? child) (string child)
+      (string? child) (escape (safely children))
+      (number? child) (string (safely children))
       (nil? child) ""
       (empty? child) ""
       :else children)))

--- a/src/joy/logger.janet
+++ b/src/joy/logger.janet
@@ -86,7 +86,8 @@
     (log (request-struct request options))
     (def response (handler request))
     (def end-seconds (os/clock))
-    (put request :duration (string/format "%.4fms" (- end-seconds start-seconds)))
+    (def delta (- end-seconds start-seconds))
+    (put request :duration (string/format "%dms" (math/ceil (* delta 1000))))
     (when response
       (log (response-struct request response start-seconds end-seconds)))
 


### PR DESCRIPTION
When I put too many arguments to a HTML structure, they get eaten without any error:
```
[:h1 "You found joy!" "this" "is" "bob" 2]
```

Only `<h1>You found joy!</h1>` is being rendered, the rest just gets dropped. Looks like in `html.janet` in `create-children` only the first child is used if it's a string or number. The rest just gets dropped.

Should probably show some kind of warning, or even error? I found out accidentally when I put some text in the wrong place and it wouldn't show up.

This code change doesn't really address the issue well, just kind of a proof of concept of how it could be done. Open to suggestions or if there's a better way to handle it. This feels.. not systematic.