### PR TITLE
Add CORS middleware

### DIFF
--- a/src/joy/middleware.janet
+++ b/src/joy/middleware.janet
@@ -207,3 +207,25 @@
           (file/close f))
         response)
       (handler request))))
+
+(defn cors [handler &opt opts]
+  `This middleware will allow CORS access. Both simple and
+   preflight OPTIONS requests are handled.
+
+   A set of minimal, sensible default CORS options are provided,
+   but can and should be customized by the user with their desired settings.
+
+   The defaults allow only GET and OPTIONS requests from all origins with a
+   24-hour max-age.`
+  (default opts @{})
+  (def default-options @{"Access-Control-Allow-Origin" "*"
+                         "Access-Control-Allow-Methods" "GET, OPTIONS"
+                         "Access-Control-Allow-Headers" "Content-Type"
+                         "Access-Control-Max-Age" 86400})
+  (def options (merge default-options opts))
+  (fn [request]
+    (if (= "OPTIONS" (get request :method))
+      @{:status 204 :body "" :headers options}
+      (let [response (handler request)]
+        (when response
+          (update response :headers merge options))))))


### PR DESCRIPTION
There are no tests with this PR.  I didn't see much in the way of integration tests in the codebase yet.  

I can try to add some tests for this middleware if you want, but it appeared that the existing testing around middleware was, for the most part, non-existent as of now.

This is still a pretty simple (naive) implementation of CORS.  Let me know if you want the default expanded on.  Many CORS libs include all methods, and various other headers by default.  This implementation currently also does not handle CORS credentials flags or the `Vary` header.

If you want these things included, then the work here can be expanded on.