### PR TITLE
Dockerfile improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,12 +9,13 @@ ARG USER=app
 ARG GROUP=app
 ARG UID=1101
 ARG GID=1101
+ARG JANET=1.12.2
 
 RUN addgroup -g $GID -S $GROUP
 RUN adduser -u $UID -S $USER -G $GROUP
 
 # Move to tmp and install janet
-RUN git clone --depth 1 --branch v1.12.1 https://github.com/janet-lang/janet.git /tmp/janet && \
+RUN git clone --depth 1 --branch v$JANET https://github.com/janet-lang/janet.git /tmp/janet && \
     cd /tmp/janet && \
     make all test install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM docker.io/alpine:3.11
 
 EXPOSE 8000
 


### PR DESCRIPTION
As discussed in #77 I made the update.
I added one more tiny change which seemed fit. Instead of having to frequently update  janet language in the docker file, you can now pass it as a built time argument:
```
docker build --build-arg JANET=1.12.1 -f docker/Dockerfile .
```

I hope this is fine.
