### PR TITLE
Make validate-element errors a bit more clear

### DIFF
--- a/src/joy/html.janet
+++ b/src/joy/html.janet
@@ -121,11 +121,11 @@
 (defn- validate-element
   [name attrs children]
   (unless (keyword? name)
-          (error "name must be a keyword"))
+          (error "tag name must be a keyword, such as :a, :div or :h3"))
   (unless (dictionary? attrs)
-          (error "attributes must be a dictionary"))
+          (error "tag attributes must be a dictionary, such as {:class \"code\" }"))
   (unless (valid-children? children)
-          (error "children must be a string, number, or index")))
+          (error "tag children must be a string, number, array, or tuple")))
 
 
 (defn- create-element


### PR DESCRIPTION
So, I've been using joy's html/encode to help get Praxis's html rendering off the ground, and the `name must be a keyword` error had me spinning my wheels for a few hours, because I thought it was talking about the value of the name attribute.

I've added what I hope are clarifying edits to the validate-element error messages, to help save the next person from getting lost down the same hole I did.