### PR TITLE
Update html-test.janet

### DIFF
--- a/test/joy/html-test.janet
+++ b/test/joy/html-test.janet
@@ -133,5 +133,5 @@
   (test "html with mixed strings and elements"
         (let [name "some name"
               proj {:description "some description" :url "http://example.com"}]
-          (= "<li><a href=\"http://example.com\">some name</a>-some description</li>"
-             (html/html [:li [:a {:href (proj :url)} name] (string "-" (proj :description))])))))
+          (= "<li><a href=\"http://example.com\">some name</a> - some description</li>"
+             (html/html [:li [:a {:href (proj :url)} name] " - " (proj :description)])))))


### PR DESCRIPTION
I typo'd when originally having that extra call to `string` in gitter. It's my understanding that janet-html should actually allow as many items as desired inside the `[:li ... ]`, no need to concat them by wrapping them up in a call to `string`.

