### PR TITLE
Check for existence of entr before invoking

### DIFF
--- a/src/joy/template/project.janet
+++ b/src/joy/template/project.janet
@@ -9,8 +9,9 @@
   :repo "")
 
 (phony "server" []
-  (if (= "development" (os/getenv "JOY_ENV"))
-      # TODO check if entr exists
+  (if (and
+       (= "development" (os/getenv "JOY_ENV"))
+       (zero? (os/shell "which entr &> /dev/null")))
     (os/shell "find . -name '*.janet' | entr janet main.janet")
     (os/shell "janet main.janet")))
 

--- a/src/joy/template/project.janet
+++ b/src/joy/template/project.janet
@@ -11,7 +11,7 @@
 (phony "server" []
   (if (and
        (= "development" (os/getenv "JOY_ENV"))
-       (zero? (os/shell "which entr &> /dev/null")))
+       (zero? (os/shell "command -v entr &> /dev/null")))
     (os/shell "find . -name '*.janet' | entr janet main.janet")
     (os/shell "janet main.janet")))
 


### PR DESCRIPTION
This will remove the "TODO" not and first check if `entr` is available for use