### PR TITLE
Multipart bug fixes

### DIFF
--- a/src/joy/csrf.janet
+++ b/src/joy/csrf.janet
@@ -31,6 +31,9 @@
 
 (defn- request-token [request]
   (or (get-in request [:body :__csrf-token])
+      (as-> (get request :multipart-body []) ?
+            (some |(if (= "__csrf-token" (get $ :name)) $ nil) ?)
+            (get ? :content))
       (x-csrf-token request)))
 
 

--- a/src/joy/http.janet
+++ b/src/joy/http.janet
@@ -143,8 +143,12 @@
 (defn parse-multipart-body [request]
   (let [boundary (multipart-boundary request)
         splitter (string "--" boundary "\r\n")
+        suffix (string "\r\n--" boundary "--\r\n")
         body (as-> (get request :body) ?
-                   (string/trimr ? (string boundary "--\r\n")))]
+                   (if (string/has-suffix? suffix ?)
+                     (string/slice ? 0 (- (+ 1 (length suffix))))
+                     ?))]
+
     (as-> (string/split splitter body) ?
           (filter |(not (empty? $)) ?)
           (map multipart ?)

--- a/test/joy/csrf-test.janet
+++ b/test/joy/csrf-test.janet
@@ -1,0 +1,34 @@
+(import tester :prefix "" :exit true)
+(import ../../src/joy :prefix "")
+
+
+(deftest
+  (let [token @"\xCC\\\xF0Y5|38\x9E\xD9\x05<\x06\x99\xE3=\xE3\xD9\x9Ch\xFD3@?\x98\x11\xC6b\x96\"\xCB\xF2"
+        masked-token "aaaa8e1fa88cdd067b8a776058e53be1041d3ff33362b73705ca28dcaf56a35966f67e469df0ee3ee553725c5e7cd8dce7c4a39bce51f7089ddbeebe397468ab"
+        handler-response @{:status 200 :body "" :headers {"Content-Type" "text/html"}}]
+    (test "token from multipart request"
+        (let [middleware-request @{:method :post :uri "/save" :headers {"Content-Type" "multipart/form-data"} :csrf-token token :multipart-body @[{:name "test" :filename "test.txt" :size 36 :content-type "text/plain"} {:name "__csrf-token" :content masked-token}]}
+              middleware-response ((csrf-token (fn [request]
+                                                 (->> (get request :masked-token)
+                                                      (put handler-response :test-request-masked-token)))) middleware-request)]
+          (and (= 200 (get middleware-response :status))
+               (= token (get middleware-response :csrf-token))
+               (truthy? (get middleware-response :test-request-masked-token)))))
+
+    (test "token from form request"
+          (let [middleware-request @{:method :post :uri "/save" :headers {"Content-Type" "application/x-www-form-urlencoded"} :csrf-token token :body {:some "thing" :__csrf-token masked-token}}
+                middleware-response ((csrf-token (fn [request]
+                                                   (->> (get request :masked-token)
+                                                        (put handler-response :test-request-masked-token)))) middleware-request)]
+            (and (= 200 (get middleware-response :status))
+                 (= token (get middleware-response :csrf-token))
+                 (truthy? (get middleware-response :test-request-masked-token)))))
+
+    (test "token from request with header"
+          (let [middleware-request @{:method :post :uri "/save" :headers {"Content-Type" "application/json" "X-CSRF-Token" masked-token} :csrf-token token :body {:some "thing"}}
+                middleware-response ((csrf-token (fn [request]
+                                                   (->> (get request :masked-token)
+                                                        (put handler-response :test-request-masked-token)))) middleware-request)]
+            (and (= 200 (get middleware-response :status))
+                 (= token (get middleware-response :csrf-token))
+                 (truthy? (get middleware-response :test-request-masked-token)))))))

--- a/test/joy/http-test.janet
+++ b/test/joy/http-test.janet
@@ -107,4 +107,30 @@
                                  :filename (get $ :filename)
                                  :size (get $ :size)
                                  :content-type (get $ :content-type))
+                        ?)))))
+
+  (test "parse-multipart-body, trimming bug"
+    (deep= @[{:name "number" :content "1"}]
+           (let [sample-body "--------------------------1\r\nContent-Disposition: form-data; name=\"number\"\r\n\r\n1\r\n--------------------------1--\r\n"
+                 request {:headers {"Content-Type" "multipart/form-data; boundary=------------------------1"}
+                          :body sample-body}]
+             (as-> (http/parse-multipart-body request) ?
+                   (map |(struct :name (get $ :name)
+                                 :content (get $ :content)
+                                 :filename (get $ :filename)
+                                 :size (get $ :size)
+                                 :content-type (get $ :content-type))
+                        ?)))))
+
+  (test "parse-multipart-body, handling wrong suffix to trim"
+    (deep= @[{:name "number" :content "1"}]
+           (let [sample-body "--------------------------1\r\nContent-Disposition: form-data; name=\"number\"\r\n\r\n1\r\n"
+                 request {:headers {"Content-Type" "multipart/form-data; boundary=------------------------1"}
+                          :body sample-body}]
+             (as-> (http/parse-multipart-body request) ?
+                   (map |(struct :name (get $ :name)
+                                 :content (get $ :content)
+                                 :filename (get $ :filename)
+                                 :size (get $ :size)
+                                 :content-type (get $ :content-type))
                         ?))))))


### PR DESCRIPTION
Hi! This PR fixes two problems:

* The csrf token wasn't taken from multipart body
* The multipart body parser used function `string/trimr` with a second argument. This argument passes a set of chars being treated as whitespace. Each of these chars are trimmed by this function from the end of the string. So, if data string ended with some of these chars, it was trimmed also.