### PR TITLE
Fix expected hashmap key order in joy-test.janet

### DIFF
--- a/test/joy-test.janet
+++ b/test/joy-test.janet
@@ -127,7 +127,7 @@
 
   (test "get request can return json"
         (is (deep= @{:status 200
-                     :body @`{"array":[1,2,3],"name":"value"}`
+                     :body @`{"name":"value","array":[1,2,3]}`
                      :headers @{"Content-Type" "application/json"}}
 
                    (let [# route functions


### PR DESCRIPTION
The keys are in the wrong order, causing the test to fail. It's fairly brittle, as a random change to Janet internals could change the output order again - but hashmaps don't care about order, so this is just kicking the bucket down the road.